### PR TITLE
[#5] Error enumeration for `Serial` peripherals

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,17 +29,24 @@ pub enum SpiError {
     /// Implementation specific error (shared across all peripheral specific error kinds)
     Impl(ImplError),
 }
+
+/// A Serial specific error.
+///
+/// This error type contains errors specific to Serial peripherals. Also it has an `Impl` kind to pass
+/// through implementation specific errors occurring while trying to use a Serial peripheral.
 #[non_exhaustive]
 pub enum SerialError{
     /// The peripheral receive buffer was overrun
     Overrun,
-    /// Framing error occurred
-    /// e.g. configuration mismatch between the TX and the RX devices.
-    Framing,
+    /// Received data does not conform to the peripheral configuration
+    /// Can be caused by a misconfigured device on either end of the serial line.
+    FrameFormatError,
     /// Parity check failed.
     Parity,
     /// Serial line is too noisy to read valid data.
     Noisy,
+    /// Implementation specific error (shared across all peripheral specific error kinds)
+    Impl(ImplError),
 }
 
 /// An I2C specific error.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub enum SerialError {
     /// Parity check failed.
     Parity,
     /// Serial line is too noisy to read valid data.
-    Noisy,
+    Noise,
     /// Implementation specific error (shared across all peripheral specific error kinds).
     Impl(ImplError),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,18 @@ pub enum SpiError {
     /// Implementation specific error (shared across all peripheral specific error kinds)
     Impl(ImplError),
 }
+#[non_exhaustive]
+pub enum SerialError{
+    /// The peripheral receive buffer was overrun
+    Overrun,
+    /// Framing error occurred
+    /// e.g. configuration mismatch between the TX and the RX devices.
+    Framing,
+    /// Parity check failed.
+    Parity,
+    /// Serial line is too noisy to read valid data.
+    Noisy,
+}
 
 /// An I2C specific error.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ pub enum SerialError {
     Overrun,
     /// Received data does not conform to the peripheral configuration
     /// Can be caused by a misconfigured device on either end of the serial line.
-    FrameFormatError,
+    FrameFormat,
     /// Parity check failed.
     Parity,
     /// Serial line is too noisy to read valid data.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,16 +36,16 @@ pub enum SpiError {
 /// through implementation specific errors occurring while trying to use a Serial peripheral.
 #[non_exhaustive]
 pub enum SerialError {
-    /// The peripheral receive buffer was overrun
+    /// The peripheral receive buffer was overrun.
     Overrun,
-    /// Received data does not conform to the peripheral configuration
+    /// Received data does not conform to the peripheral configuration.
     /// Can be caused by a misconfigured device on either end of the serial line.
     FrameFormat,
     /// Parity check failed.
     Parity,
     /// Serial line is too noisy to read valid data.
     Noisy,
-    /// Implementation specific error (shared across all peripheral specific error kinds)
+    /// Implementation specific error (shared across all peripheral specific error kinds).
     Impl(ImplError),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ pub enum SpiError {
 /// This error type contains errors specific to Serial peripherals. Also it has an `Impl` kind to pass
 /// through implementation specific errors occurring while trying to use a Serial peripheral.
 #[non_exhaustive]
-pub enum SerialError{
+pub enum SerialError {
     /// The peripheral receive buffer was overrun
     Overrun,
     /// Received data does not conform to the peripheral configuration


### PR DESCRIPTION
This PR adds a non-exhaustive serial error enumeration.

I used the stm32f4 and h7 crates for reference (I use the f4 crate for my projects), though altered the `Framing` error variant to conform with the existing SPI enum which I found to be more descriptive. The first time I encountered a `Framing` variant in the f4 hal, I had great difficulty discerning what it actually meant (in my case: configuration mismatch).

Questions I do have before this gets merged: 
1. should `Parity` be named `BadParity` or something of the sort, it suffers from a similar naming issue as `Framing` does in the current HALs. 
2. Are there other generic errors that can occur with Serial that I am overlooking?

closes #5 